### PR TITLE
Fix #4

### DIFF
--- a/HDL_Converter_App/HDL_Converter_Classes/HDL_Structures/VerilogConstructs.cs
+++ b/HDL_Converter_App/HDL_Converter_Classes/HDL_Structures/VerilogConstructs.cs
@@ -300,6 +300,10 @@ namespace HDL_Converter_Classes.HDL_Structures
         public static List<string[]> separateElements(string hdlCode)
         {
             List<string[]> retList = new List<string[]>();
+            string[] initialEntry = new string[2];
+            initialEntry[0] = "";
+            initialEntry[1] = "";
+            retList.Add(initialEntry);
             string[] hdlSplited = hdlCode.Replace("//", "//{Comment}").Split(new string[] { System.Environment.NewLine, "//" }, StringSplitOptions.None);
             foreach (string element in hdlSplited)
             {

--- a/HDL_Converter_App/HDL_Converter_Test/Test_Data/Verilog_Wire_Separate_Elements.txt
+++ b/HDL_Converter_App/HDL_Converter_Test/Test_Data/Verilog_Wire_Separate_Elements.txt
@@ -2,23 +2,23 @@
 input wire[4:0] addr,
 input wire[5:0] someSig,
 output wire[255:0] otherSig
-$input wire we||input wire[4:0] addr||input wire[5:0] someSig||output wire[255:0] otherSig|$
+$||input wire we||input wire[4:0] addr||input wire[5:0] someSig||output wire[255:0] otherSig|$
 input wire we, //Comment 1
 input wire[4:0] addr, //Comment 2
 input wire[5:0] someSig,
 output wire[255:0] otherSig //Comment 3
-$input wire we|Comment 1|input wire[4:0] addr|Comment 2|input wire[5:0] someSig||output wire[255:0] otherSig|Comment 3$
+$||input wire we|Comment 1|input wire[4:0] addr|Comment 2|input wire[5:0] someSig||output wire[255:0] otherSig|Comment 3$
 input wire we, //I / wirte / more/ comm,ts
 input wire[4:0] addr, //Comment 2
 input wire[5:0] someSig //I / like / to /Implant, tese
-$input wire we|I / wirte / more/ comm,ts|input wire[4:0] addr|Comment 2|input wire[5:0] someSig|I / like / to /Implant, tese$
+$||input wire we|I / wirte / more/ comm,ts|input wire[4:0] addr|Comment 2|input wire[5:0] someSig|I / like / to /Implant, tese$
 input wire we,  input wire[4:0] addr, input wire[5:0] someSig, output wire[255:0] otherSig
-$input wire we||input wire[4:0] addr||input wire[5:0] someSig||output wire[255:0] otherSig|$
+$||input wire we||input wire[4:0] addr||input wire[5:0] someSig||output wire[255:0] otherSig|$
 parameter param1 = 12,
 parameter param2 = 2,
 parameter param3 = 'h0A
-$parameter param1 = 12||parameter param2 = 2||parameter param3 = 'h0A|$
+$||parameter param1 = 12||parameter param2 = 2||parameter param3 = 'h0A|$
 parameter param1 = 12, //Comment 1
 parameter param2 = 2,  
 parameter param3 = 'h0A  //Comment 2
-$parameter param1 = 12|Comment 1|parameter param2 = 2||parameter param3 = 'h0A|Comment 2
+$||parameter param1 = 12|Comment 1|parameter param2 = 2||parameter param3 = 'h0A|Comment 2


### PR DESCRIPTION
Fixed issue by adding an initial (empty) entry to the list such that null reference when first line is a comment (not a signal) is removed